### PR TITLE
Work with eco item

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,10 +65,14 @@ dependencies {
     // EnchantsSquaredRewritten
     compileOnly(files("libs/EnchantsSquared.jar"))
 
-    // EcoEnchants
-    compileOnly("com.willfp:EcoEnchants:12.11.1")
+    // EcoEnchants & item
+    compileOnly("com.willfp:libreforge:4.79.0:all")
     compileOnly("com.willfp:eco:6.74.5")
+
+    compileOnly("com.willfp:EcoEnchants:12.11.1")
     compileOnly(project(":impl:LegacyEcoEnchant"))
+
+    compileOnly("com.willfp:EcoItems:5.66.0")
 
     // ExcellentEnchants
     implementation(project(":impl:ExcellentEnchant5_4"))

--- a/src/main/java/xyz/alexcrea/cuanvil/api/MaterialGroupApi.java
+++ b/src/main/java/xyz/alexcrea/cuanvil/api/MaterialGroupApi.java
@@ -3,6 +3,7 @@ package xyz.alexcrea.cuanvil.api;
 import io.delilaheve.CustomAnvil;
 import io.delilaheve.util.ConfigOptions;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -123,7 +124,7 @@ public class MaterialGroupApi {
         FileConfiguration config = ConfigHolder.ITEM_GROUP_HOLDER.getConfig();
 
         String basePath = group.getName() + ".";
-        Set<Material> materialSet = group.getNonGroupInheritedMaterials();
+        Set<NamespacedKey> materialSet = group.getNonGroupInheritedMaterials();
         Set<AbstractMaterialGroup> groupSet = group.getGroups();
 
         boolean empty = true;
@@ -153,7 +154,7 @@ public class MaterialGroupApi {
         FileConfiguration config = ConfigHolder.ITEM_GROUP_HOLDER.getConfig();
 
         String basePath = group.getName() + ".";
-        EnumSet<Material> materials = group.getMaterials();
+        Set<NamespacedKey> materials = group.getMaterials();
 
         if (materials.isEmpty()) return false;
 
@@ -163,8 +164,8 @@ public class MaterialGroupApi {
         return true;
     }
 
-    public static List<String> materialSetToStringList(@NotNull Set<Material> materials) {
-        return materials.stream().map(material -> material.getKey().getKey().toLowerCase()).toList();
+    public static List<String> materialSetToStringList(@NotNull Set<NamespacedKey> materials) {
+        return materials.stream().map(NamespacedKey::toString).toList();
     }
 
     public static List<String> materialGroupSetToStringList(@NotNull Set<AbstractMaterialGroup> groups) {

--- a/src/main/java/xyz/alexcrea/cuanvil/enchant/AdditionalTestEnchantment.java
+++ b/src/main/java/xyz/alexcrea/cuanvil/enchant/AdditionalTestEnchantment.java
@@ -1,6 +1,7 @@
 package xyz.alexcrea.cuanvil.enchant;
 
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,24 +12,23 @@ public interface AdditionalTestEnchantment {
     /**
      * Test if the provided enchantments can be compatible with this enchantment. only non-Custom Anvil conflict.
      * @param enchantments Immutable map of validated enchantments for the item.
-     * @param itemMat Material of the tested item.
+     * @param itemType Material namespaced key of the tested item.
      * @return If there is a conflict with the enchantments.
      */
     boolean isEnchantConflict(
             @NotNull Map<CAEnchantment, Integer> enchantments,
-            @NotNull Material itemMat);
-
+            @NotNull NamespacedKey itemType);
 
     /**
      * Test if the provided item can be compatible with this enchantment. only non-Custom Anvil conflict.
      * @param enchantments Immutable map of validated enchantments for the item.
-     * @param itemMat Material of the tested item.
+     * @param itemType Material namespaced key of the tested item.
      * @param item Provide a new instance of the used item stack with the partial enchantment applied.
      * @return If there is a conflict with the enchantment and the item.
      */
     boolean isItemConflict(
             @NotNull Map<CAEnchantment, Integer> enchantments,
-            @NotNull Material itemMat,
+            @NotNull NamespacedKey itemType,
             @NotNull ItemStack item);
 
 }

--- a/src/main/java/xyz/alexcrea/cuanvil/enchant/wrapped/CAEEPreV5Enchantment.java
+++ b/src/main/java/xyz/alexcrea/cuanvil/enchant/wrapped/CAEEPreV5Enchantment.java
@@ -1,6 +1,7 @@
 package xyz.alexcrea.cuanvil.enchant.wrapped;
 
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import su.nightexpress.excellentenchants.api.enchantment.CustomEnchantment;
@@ -39,7 +40,7 @@ public class CAEEPreV5Enchantment extends CABukkitEnchantment implements Additio
     }
 
     @Override
-    public boolean isEnchantConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull Material itemMat) {
+    public boolean isEnchantConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull NamespacedKey itemType) {
         if (!definition.hasConflicts()) return false;
 
         Set<String> conflicts = definition.getConflicts();
@@ -52,8 +53,8 @@ public class CAEEPreV5Enchantment extends CABukkitEnchantment implements Additio
     }
 
     @Override
-    public boolean isItemConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull Material itemMat, @NotNull ItemStack item) {
-        if (Material.ENCHANTED_BOOK.equals(itemMat)) return false;
+    public boolean isItemConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull NamespacedKey itemType, @NotNull ItemStack item) {
+        if (Material.ENCHANTED_BOOK.getKey().equals(itemType)) return false;
 
         return !definition.getSupportedItems().is(item);
     }

--- a/src/main/java/xyz/alexcrea/cuanvil/enchant/wrapped/CAEEV5Enchantment.java
+++ b/src/main/java/xyz/alexcrea/cuanvil/enchant/wrapped/CAEEV5Enchantment.java
@@ -1,6 +1,7 @@
 package xyz.alexcrea.cuanvil.enchant.wrapped;
 
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import su.nightexpress.excellentenchants.api.enchantment.CustomEnchantment;
@@ -27,7 +28,7 @@ public class CAEEV5Enchantment extends CABukkitEnchantment implements Additional
     }
 
     @Override
-    public boolean isEnchantConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull Material itemMat) {
+    public boolean isEnchantConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull NamespacedKey itemType) {
         if (!hasConflicts()) return false;
 
         Set<String> conflicts = getExclusiveSet();
@@ -41,10 +42,10 @@ public class CAEEV5Enchantment extends CABukkitEnchantment implements Additional
     }
 
     @Override
-    public boolean isItemConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull Material itemMat, @NotNull ItemStack item) {
-        if (Material.ENCHANTED_BOOK.equals(itemMat)) return false;
+    public boolean isItemConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull NamespacedKey itemType, @NotNull ItemStack item) {
+        if (Material.ENCHANTED_BOOK.getKey().equals(itemType)) return false;
 
-        String key = itemMat.getKey().getKey();
+        String key = itemType.getKey();
         ItemSet primary = eeenchantment.getPrimaryItems();
         if (primary.getMaterials().contains(key)) return false;
 

--- a/src/main/java/xyz/alexcrea/cuanvil/enchant/wrapped/CAEcoEnchant.java
+++ b/src/main/java/xyz/alexcrea/cuanvil/enchant/wrapped/CAEcoEnchant.java
@@ -4,6 +4,7 @@ import com.willfp.ecoenchants.enchant.EcoEnchant;
 import com.willfp.ecoenchants.target.EnchantmentTarget;
 import com.willfp.ecoenchants.type.EnchantmentType;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import xyz.alexcrea.cuanvil.enchant.AdditionalTestEnchantment;
@@ -23,7 +24,7 @@ public class CAEcoEnchant extends CABukkitEnchantment implements AdditionalTestE
     }
 
     @Override
-    public boolean isEnchantConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull Material itemMat) {
+    public boolean isEnchantConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull NamespacedKey itemType) {
         if (enchantments.isEmpty()) return false;
 
         // Check if there is only self
@@ -61,9 +62,9 @@ public class CAEcoEnchant extends CABukkitEnchantment implements AdditionalTestE
 
     @Override
     public boolean isItemConflict(@NotNull Map<CAEnchantment, Integer> enchantments,
-                                  @NotNull Material itemMat,
+                                  @NotNull NamespacedKey itemType,
                                   @NotNull ItemStack item) {
-        if (Material.ENCHANTED_BOOK.equals(itemMat)) {
+        if (Material.ENCHANTED_BOOK.getKey().equals(itemType)) {
             return false;
         }
 

--- a/src/main/java/xyz/alexcrea/cuanvil/enchant/wrapped/CAIncompatibleAllEnchant.java
+++ b/src/main/java/xyz/alexcrea/cuanvil/enchant/wrapped/CAIncompatibleAllEnchant.java
@@ -1,6 +1,7 @@
 package xyz.alexcrea.cuanvil.enchant.wrapped;
 
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -24,12 +25,12 @@ public class CAIncompatibleAllEnchant extends CABukkitEnchantment implements Add
 
 
     @Override
-    public boolean isEnchantConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull Material itemMat) {
+    public boolean isEnchantConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull NamespacedKey itemType) {
         return !enchantments.isEmpty() && !(enchantments.size() == 1 && enchantments.containsKey(this));
     }
 
     @Override
-    public boolean isItemConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull Material itemMat, @NotNull ItemStack item) {
+    public boolean isItemConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull NamespacedKey itemType, @NotNull ItemStack item) {
         return false;
     }
 }

--- a/src/main/java/xyz/alexcrea/cuanvil/enchant/wrapped/CALegacyEEEnchantment.java
+++ b/src/main/java/xyz/alexcrea/cuanvil/enchant/wrapped/CALegacyEEEnchantment.java
@@ -1,6 +1,7 @@
 package xyz.alexcrea.cuanvil.enchant.wrapped;
 
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import su.nightexpress.excellentenchants.api.enchantment.EnchantmentData;
@@ -22,7 +23,7 @@ public class CALegacyEEEnchantment extends CABukkitEnchantment implements Additi
     }
 
     @Override
-    public boolean isEnchantConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull Material itemMat) {
+    public boolean isEnchantConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull NamespacedKey itemType) {
         if (!eeenchantment.hasConflicts()) return false;
 
         Set<String> conflicts = eeenchantment.getConflicts();
@@ -35,8 +36,8 @@ public class CALegacyEEEnchantment extends CABukkitEnchantment implements Additi
     }
 
     @Override
-    public boolean isItemConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull Material itemMat, @NotNull ItemStack item) {
-        if (Material.ENCHANTED_BOOK.equals(itemMat)) return false;
+    public boolean isItemConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull NamespacedKey itemType, @NotNull ItemStack item) {
+        if (Material.ENCHANTED_BOOK.getKey().equals(itemType)) return false;
 
         return !eeenchantment.getSupportedItems().is(item);
     }

--- a/src/main/java/xyz/alexcrea/cuanvil/enchant/wrapped/CALegacyEcoEnchant.java
+++ b/src/main/java/xyz/alexcrea/cuanvil/enchant/wrapped/CALegacyEcoEnchant.java
@@ -4,12 +4,14 @@ import com.willfp.ecoenchants.enchantments.EcoEnchant;
 import com.willfp.ecoenchants.enchantments.meta.EnchantmentTarget;
 import com.willfp.ecoenchants.enchantments.meta.EnchantmentType;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import xyz.alexcrea.cuanvil.enchant.AdditionalTestEnchantment;
 import xyz.alexcrea.cuanvil.enchant.CAEnchantment;
 import xyz.alexcrea.cuanvil.enchant.EnchantmentRarity;
+import xyz.alexcrea.cuanvil.util.MaterialUtil;
 
 import java.util.Map;
 
@@ -23,7 +25,7 @@ public class CALegacyEcoEnchant extends CABukkitEnchantment implements Additiona
     }
 
     @Override
-    public boolean isEnchantConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull Material itemMat) {
+    public boolean isEnchantConflict(@NotNull Map<CAEnchantment, Integer> enchantments, @NotNull NamespacedKey itemType) {
         if (enchantments.isEmpty()) return false;
 
         EnchantmentType type = this.ecoEnchant.getType();
@@ -48,14 +50,15 @@ public class CALegacyEcoEnchant extends CABukkitEnchantment implements Additiona
 
     @Override
     public boolean isItemConflict(@NotNull Map<CAEnchantment, Integer> enchantments,
-                                  @NotNull Material itemMat,
+                                  @NotNull NamespacedKey itemType,
                                   @NotNull ItemStack item) {
-        if (Material.ENCHANTED_BOOK.equals(itemMat)) {
+        if (Material.ENCHANTED_BOOK.getKey().equals(itemType)) {
             return false;
         }
 
+        var mat = MaterialUtil.INSTANCE.getMatFromKey(itemType);
         for (EnchantmentTarget target : this.ecoEnchant.getTargets()) {
-            if (target.getMaterials().contains(itemMat)) {
+            if (target.getMaterials().contains(mat)) {
                 return false;
             }
         }

--- a/src/main/java/xyz/alexcrea/cuanvil/gui/config/SelectMaterialContainer.java
+++ b/src/main/java/xyz/alexcrea/cuanvil/gui/config/SelectMaterialContainer.java
@@ -1,34 +1,35 @@
 package xyz.alexcrea.cuanvil.gui.config;
 
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import xyz.alexcrea.cuanvil.util.CasedStringUtil;
 
 import java.util.*;
 
 public interface SelectMaterialContainer {
 
-    EnumSet<Material> getSelectedMaterials();
+    Set<NamespacedKey> getSelectedMaterials();
 
-    boolean setSelectedMaterials(EnumSet<Material> materials);
+    boolean setSelectedMaterials(Set<NamespacedKey> materials);
 
-    EnumSet<Material> illegalMaterials();
+    Set<NamespacedKey> illegalMaterials();
 
     static List<String> getMaterialLore(SelectMaterialContainer container, String containerType, String action){
         // Prepare material lore
         ArrayList<String> groupLore = new ArrayList<>();
         groupLore.add("§7Allow you to select a list of §ematerials §7that this " + containerType + " should " + action);
-        Set<Material> materialSet = container.getSelectedMaterials();
+        Set<NamespacedKey> materialSet = container.getSelectedMaterials();
         if (materialSet.isEmpty()) {
             groupLore.add("§7There is no "+action+"d material for this "+containerType+".");
         } else {
             groupLore.add("§7List of "+action+"d materials for this "+containerType+":");
-            Iterator<Material> materialIterator = materialSet.iterator();
+            Iterator<NamespacedKey> materialIterator = materialSet.iterator();
 
             boolean greaterThanMax = materialSet.size() > 5;
             int maxindex = (greaterThanMax ? 4 : materialSet.size());
             for (int i = 0; i < maxindex; i++) {
                 // format string like "- Stone Sword"
-                String formattedName = CasedStringUtil.snakeToUpperSpacedCase(materialIterator.next().name().toLowerCase());
+                String formattedName = CasedStringUtil.snakeToUpperSpacedCase(materialIterator.next().getKey().toLowerCase());
                 groupLore.add("§7- §e" + formattedName);
 
             }

--- a/src/main/java/xyz/alexcrea/cuanvil/gui/config/ask/SelectItemTypeGui.java
+++ b/src/main/java/xyz/alexcrea/cuanvil/gui/config/ask/SelectItemTypeGui.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.NotNull;
 import xyz.alexcrea.cuanvil.gui.util.GuiGlobalActions;
 import xyz.alexcrea.cuanvil.gui.util.GuiGlobalItems;
 import xyz.alexcrea.cuanvil.gui.util.GuiSharedConstant;
+import xyz.alexcrea.cuanvil.util.MaterialUtil;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
@@ -52,7 +53,7 @@ public class SelectItemTypeGui extends AbstractAskGui {
             event.setCancelled(true);
 
             ItemStack cursor = event.getWhoClicked().getItemOnCursor();
-            if(cursor.getType().isAir()) return;
+            if(MaterialUtil.INSTANCE.isAir(cursor)) return;
 
             ItemStack finalItem;
             if(materialOnly){

--- a/src/main/java/xyz/alexcrea/cuanvil/gui/config/list/elements/GroupConfigSubSettingGui.java
+++ b/src/main/java/xyz/alexcrea/cuanvil/gui/config/list/elements/GroupConfigSubSettingGui.java
@@ -5,6 +5,7 @@ import com.github.stefvanschie.inventoryframework.pane.PatternPane;
 import com.github.stefvanschie.inventoryframework.pane.util.Pattern;
 import io.delilaheve.CustomAnvil;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemFlag;
@@ -325,19 +326,19 @@ public class GroupConfigSubSettingGui extends MappedToListSubSettingGui implemen
     // ----------------------------
 
     @Override
-    public EnumSet<Material> getSelectedMaterials() {
+    public Set<NamespacedKey> getSelectedMaterials() {
         return this.group.getNonGroupInheritedMaterials();
     }
 
     @Override
-    public boolean setSelectedMaterials(EnumSet<Material> materials) {
+    public boolean setSelectedMaterials(Set<NamespacedKey> materials) {
         this.group.setNonGroupInheritedMaterials(materials);
 
         // Write to file configuration
         String[] groupNames = new String[materials.size()];
         int index = 0;
-        for (Material otherGroup : materials) {
-            groupNames[index++] = otherGroup.name().toLowerCase();
+        for (NamespacedKey otherGroup : materials) {
+            groupNames[index++] = otherGroup.getKey().toLowerCase();
         }
 
         ConfigHolder.ITEM_GROUP_HOLDER.getConfig().set(this.group.getName()+"."+ItemGroupManager.MATERIAL_LIST_PATH, groupNames);
@@ -353,8 +354,8 @@ public class GroupConfigSubSettingGui extends MappedToListSubSettingGui implemen
     }
 
     @Override
-    public EnumSet<Material> illegalMaterials() {
-        return EnumSet.of(Material.AIR);
+    public Set<NamespacedKey> illegalMaterials() {
+        return Set.of(Material.AIR.getKey());
     }
 
     // ----------------------------

--- a/src/main/java/xyz/alexcrea/cuanvil/gui/config/settings/MaterialSelectSettingGui.java
+++ b/src/main/java/xyz/alexcrea/cuanvil/gui/config/settings/MaterialSelectSettingGui.java
@@ -5,6 +5,7 @@ import com.github.stefvanschie.inventoryframework.gui.type.util.Gui;
 import com.github.stefvanschie.inventoryframework.pane.util.Pattern;
 import io.delilaheve.CustomAnvil;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemFlag;
@@ -18,18 +19,19 @@ import xyz.alexcrea.cuanvil.gui.util.GuiGlobalActions;
 import xyz.alexcrea.cuanvil.gui.util.GuiGlobalItems;
 import xyz.alexcrea.cuanvil.gui.util.GuiSharedConstant;
 import xyz.alexcrea.cuanvil.util.CasedStringUtil;
+import xyz.alexcrea.cuanvil.util.MaterialUtil;
 
 import java.util.*;
 import java.util.function.Consumer;
 
-public class MaterialSelectSettingGui extends MappedElementListConfigGui<Material, GuiItem> {
+public class MaterialSelectSettingGui extends MappedElementListConfigGui<NamespacedKey, GuiItem> {
 
     private final SelectMaterialContainer selector;
     private final Gui backGui;
     private boolean instantRemove;
 
-    private final List<Material> defaultMaterials;
-    private final EnumSet<Material> illegalMaterials;
+    private final List<NamespacedKey> defaultMaterials;
+    private final Set<NamespacedKey> illegalMaterials;
     private final int defaultMaterialHash;
     private int nowMaterialHash;
 
@@ -161,8 +163,7 @@ public class MaterialSelectSettingGui extends MappedElementListConfigGui<Materia
 
 
             // Save setting
-            EnumSet<Material> result = EnumSet.noneOf(Material.class);
-            result.addAll(this.elementGuiMap.keySet());
+            Set<NamespacedKey> result = new HashSet<>(this.elementGuiMap.keySet());
 
             if(!this.selector.setSelectedMaterials(result)){
                 player.sendMessage("§cSomething went wrong while saving the change of value.");
@@ -185,8 +186,8 @@ public class MaterialSelectSettingGui extends MappedElementListConfigGui<Materia
             ItemStack cursor = player.getItemOnCursor();
 
             // Test if cursor material allowed
-            Material cursorMat = cursor.getType();
-            if(cursorMat.isAir()) return;
+            NamespacedKey cursorMat = MaterialUtil.INSTANCE.getCustomType(cursor);
+            if(MaterialUtil.INSTANCE.isAir(cursorMat)) return;
             if(this.illegalMaterials.contains(cursorMat)) return;
 
             // Update gui only if item did not exist before.
@@ -201,12 +202,12 @@ public class MaterialSelectSettingGui extends MappedElementListConfigGui<Materia
     }
 
     @Override
-    protected ItemStack createItemForGeneric(Material material) {
-        ItemStack item = new ItemStack(material);
+    protected ItemStack createItemForGeneric(NamespacedKey material) {
+        ItemStack item = new ItemStack(Objects.requireNonNull(MaterialUtil.INSTANCE.getMatFromKey(material)));
         ItemMeta meta = item.getItemMeta();
 
         if(meta == null) return item;
-        meta.setDisplayName("§a" + CasedStringUtil.snakeToUpperSpacedCase(material.name().toLowerCase()));
+        meta.setDisplayName("§a" + CasedStringUtil.snakeToUpperSpacedCase(material.getKey().toLowerCase()));
         meta.setLore(Collections.singletonList("§7Click here to remove this material from the list"));
         meta.addItemFlags(ItemFlag.values());
 
@@ -216,22 +217,22 @@ public class MaterialSelectSettingGui extends MappedElementListConfigGui<Materia
     }
 
     @Override
-    protected Collection<Material> getEveryDisplayableInstanceOfGeneric() {
+    protected Collection<NamespacedKey> getEveryDisplayableInstanceOfGeneric() {
         return this.defaultMaterials;
     }
 
     @Override
-    protected void updateElement(Material material, GuiItem element) {
+    protected void updateElement(NamespacedKey material, GuiItem element) {
         // Nothing happen here I think
     }
 
     @Override
-    protected GuiItem newElementRequested(Material material, GuiItem newItem) {
+    protected GuiItem newElementRequested(NamespacedKey material, GuiItem newItem) {
         newItem.setAction(event -> {
             if(this.instantRemove){
                 removeMaterial(material);
             }else {
-                String materialName = CasedStringUtil.snakeToUpperSpacedCase(material.name().toLowerCase());
+                String materialName = CasedStringUtil.snakeToUpperSpacedCase(material.getKey().toLowerCase());
 
                 // Create and show confirm remove gui.
                 ConfirmActionGui confirmGui = new ConfirmActionGui(
@@ -250,7 +251,7 @@ public class MaterialSelectSettingGui extends MappedElementListConfigGui<Materia
         return newItem;
     }
 
-    private void removeMaterial(Material material) {
+    private void removeMaterial(NamespacedKey material) {
         if(this.elementGuiMap.containsKey(material)){
             this.nowMaterialHash ^= material.hashCode();
             setSaveItem();
@@ -260,18 +261,18 @@ public class MaterialSelectSettingGui extends MappedElementListConfigGui<Materia
     }
 
     @Override
-    protected GuiItem findItemFromElement(Material generic, GuiItem element) {
+    protected GuiItem findItemFromElement(NamespacedKey generic, GuiItem element) {
         return element;
     }
 
     @Override
-    protected GuiItem findGuiItemForRemoval(Material generic, GuiItem element) {
+    protected GuiItem findGuiItemForRemoval(NamespacedKey generic, GuiItem element) {
         return element;
     }
 
-    private static int hashFromMaterialList(List<Material> materialList){
+    private static int hashFromMaterialList(List<NamespacedKey> materialList){
         int defaultMaterialHash = 0;
-        for (Material material : materialList) {
+        for (NamespacedKey material : materialList) {
             defaultMaterialHash ^= material.hashCode();
         }
         return defaultMaterialHash;

--- a/src/main/java/xyz/alexcrea/cuanvil/update/plugin/PUpdate_1_11_0.java
+++ b/src/main/java/xyz/alexcrea/cuanvil/update/plugin/PUpdate_1_11_0.java
@@ -1,6 +1,7 @@
 package xyz.alexcrea.cuanvil.update.plugin;
 
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.jetbrains.annotations.NotNull;
@@ -11,6 +12,7 @@ import xyz.alexcrea.cuanvil.group.AbstractMaterialGroup;
 import xyz.alexcrea.cuanvil.group.IncludeGroup;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -69,7 +71,12 @@ public class PUpdate_1_11_0 {
 
         // Create new group
         IncludeGroup group = new IncludeGroup(toolset);
-        group.addAll(toolMats);
+        NamespacedKey[] keys = new NamespacedKey[toolMats.length];
+        for (int i = 0; i < toolMats.length; i++) {
+            keys[i] = toolMats[i].getKey();
+        }
+
+        group.addAll(keys);
 
         MaterialGroupApi.addMaterialGroup(group, true);
 
@@ -77,8 +84,8 @@ public class PUpdate_1_11_0 {
         if (tools == null) return;
         if (!(tools instanceof IncludeGroup include)) return;
 
-        List<Material> mats = List.of(toolMats);
-        Set<Material> matSet = include.getNonGroupInheritedMaterials();
+        List<NamespacedKey> mats = List.of(keys);
+        Set<NamespacedKey> matSet = include.getNonGroupInheritedMaterials();
         if (!matSet.containsAll(mats)) return;
 
         mats.forEach(matSet::remove);

--- a/src/main/kotlin/io/delilaheve/util/ConfigOptions.kt
+++ b/src/main/kotlin/io/delilaheve/util/ConfigOptions.kt
@@ -348,7 +348,7 @@ object ConfigOptions {
      *
      * @return the current enchantment limit. -1 if none
      */
-    fun getEnchantCountLimit(type: Material): Int? {
+    fun getEnchantCountLimit(type: NamespacedKey): Int? {
         val limit = materialEnchantCountLimit(type)
 
         if(limit != null) return limit
@@ -362,8 +362,8 @@ object ConfigOptions {
      *
      * @return The current enchantment limit. -1 if none
      */
-    private fun materialEnchantCountLimit(type: Material): Int? {
-        val path = "$ENCHANT_COUNT_LIMIT_ITEMS.${type.key.key.lowercase()}"
+    private fun materialEnchantCountLimit(type: NamespacedKey): Int? {
+        val path = "$ENCHANT_COUNT_LIMIT_ITEMS.${type.key.lowercase()}"
         if(!ConfigHolder.DEFAULT_CONFIG.config.isInt(path))
             return null
 

--- a/src/main/kotlin/io/delilaheve/util/EnchantmentUtil.kt
+++ b/src/main/kotlin/io/delilaheve/util/EnchantmentUtil.kt
@@ -6,6 +6,7 @@ import org.bukkit.inventory.ItemStack
 import xyz.alexcrea.cuanvil.config.ConfigHolder
 import xyz.alexcrea.cuanvil.enchant.CAEnchantment
 import xyz.alexcrea.cuanvil.group.ConflictType
+import xyz.alexcrea.cuanvil.util.MaterialUtil.customType
 import kotlin.math.max
 import kotlin.math.min
 
@@ -34,7 +35,7 @@ object EnchantmentUtil {
         val bypassFuse = player.hasPermission(CustomAnvil.bypassFusePermission)
         val bypassLevel = player.hasPermission(CustomAnvil.bypassLevelPermission)
 
-        var maxEnchantCount = ConfigOptions.getEnchantCountLimit(item.type)
+        var maxEnchantCount = ConfigOptions.getEnchantCountLimit(item.customType)
         if(maxEnchantCount == null || maxEnchantCount < 0) maxEnchantCount = Int.MAX_VALUE
 
         val allowed = other.filter { (enchantment, _) -> enchantment.isAllowed(player) }

--- a/src/main/kotlin/io/delilaheve/util/ItemUtil.kt
+++ b/src/main/kotlin/io/delilaheve/util/ItemUtil.kt
@@ -4,6 +4,7 @@ import org.bukkit.Material.ENCHANTED_BOOK
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.Damageable
 import xyz.alexcrea.cuanvil.enchant.CAEnchantment
+import xyz.alexcrea.cuanvil.util.MaterialUtil.customType
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.min
@@ -90,5 +91,5 @@ object ItemUtil {
      */
     fun ItemStack.canMergeWith(
         other: ItemStack?
-    ) = (other != null) && (type == other.type || (other.isEnchantedBook()))
+    ) = (other != null) && (customType == other.customType || (other.isEnchantedBook()))
 }

--- a/src/main/kotlin/xyz/alexcrea/cuanvil/dependency/datapack/DataPackDependency.kt
+++ b/src/main/kotlin/xyz/alexcrea/cuanvil/dependency/datapack/DataPackDependency.kt
@@ -145,7 +145,7 @@ object DataPackDependency {
                     CustomAnvil.instance.logger.warning("Could not find material $name for item group $groupName")
                     continue
                 }
-                group.addToPolicy(mat)
+                group.addToPolicy(mat.key)
             }
             for (name in section.getStringList("groups")) {
                 val otherGroup = MaterialGroupApi.getGroup(name)

--- a/src/main/kotlin/xyz/alexcrea/cuanvil/dependency/plugins/EcoItemDependencyUtil.kt
+++ b/src/main/kotlin/xyz/alexcrea/cuanvil/dependency/plugins/EcoItemDependencyUtil.kt
@@ -1,0 +1,34 @@
+package xyz.alexcrea.cuanvil.dependency.plugins
+
+import com.willfp.ecoitems.items.EcoItem
+import com.willfp.ecoitems.items.EcoItems
+import com.willfp.ecoitems.items.ecoItem
+import org.bukkit.Material
+import org.bukkit.NamespacedKey
+import org.bukkit.inventory.ItemStack
+
+object EcoItemDependencyUtil {
+
+    fun ecoItemNamespace(item: ItemStack): NamespacedKey? {
+        val ecoi = item.ecoItem ?: return null
+
+        return ecoi.id
+    }
+
+    fun ecoItemFromKey(key: NamespacedKey): EcoItem? {
+        return EcoItems.getByID(key.toString())
+    }
+
+    fun ecoItemMaterialFromKey(key: NamespacedKey): Material? {
+        val ecoi = ecoItemFromKey(key) ?: return null
+
+        return ecoi.itemStack.type
+    }
+
+    fun newEcoItemstack(key: NamespacedKey): ItemStack? {
+        val ecoi = ecoItemFromKey(key) ?: return null
+
+        return ecoi.itemStack
+    }
+
+}

--- a/src/main/kotlin/xyz/alexcrea/cuanvil/dependency/plugins/EnchantmentSquaredDependency.kt
+++ b/src/main/kotlin/xyz/alexcrea/cuanvil/dependency/plugins/EnchantmentSquaredDependency.kt
@@ -102,15 +102,15 @@ class EnchantmentSquaredDependency(private val enchantmentSquaredPlugin: Plugin)
     private fun writeMissingGroups(){
         // Write group that do not exist on custom anvil.
         val shield = IncludeGroup("shield")
-        shield.addToPolicy(Material.SHIELD)
+        shield.addToPolicy(Material.SHIELD.key)
         MaterialGroupApi.addMaterialGroup(shield)
 
         val elytra = IncludeGroup("elytra")
-        elytra.addToPolicy(Material.ELYTRA)
+        elytra.addToPolicy(Material.ELYTRA.key)
         MaterialGroupApi.addMaterialGroup(elytra)
 
         val trinkets = IncludeGroup("trinkets")
-        trinkets.addToPolicy(Material.ROTTEN_FLESH)
+        trinkets.addToPolicy(Material.ROTTEN_FLESH.key)
         MaterialGroupApi.addMaterialGroup(trinkets)
     }
 

--- a/src/main/kotlin/xyz/alexcrea/cuanvil/group/AbstractMaterialGroup.kt
+++ b/src/main/kotlin/xyz/alexcrea/cuanvil/group/AbstractMaterialGroup.kt
@@ -1,7 +1,8 @@
 package xyz.alexcrea.cuanvil.group
 
 import org.bukkit.Material
-import java.util.*
+import org.bukkit.NamespacedKey
+import xyz.alexcrea.cuanvil.util.MaterialUtil
 
 abstract class AbstractMaterialGroup(private val name: String) {
     protected val includedMaterial by lazy { createDefaultSet() }
@@ -9,12 +10,12 @@ abstract class AbstractMaterialGroup(private val name: String) {
     /**
      * Get the group default set
      */
-    protected abstract fun createDefaultSet(): EnumSet<Material>
+    protected abstract fun createDefaultSet(): MutableSet<NamespacedKey>
 
     /**
      * Get if a material is allowed following the group policy
      */
-    open fun contain(mat: Material): Boolean {
+    open fun contain(mat: NamespacedKey): Boolean {
         return mat in getMaterials()
     }
 
@@ -27,13 +28,13 @@ abstract class AbstractMaterialGroup(private val name: String) {
      * Push a material to this group to follow this group policy
      * @return this instance.
      */
-    abstract fun addToPolicy(mat: Material): AbstractMaterialGroup
+    abstract fun addToPolicy(type: NamespacedKey): AbstractMaterialGroup
 
     /**
      * Push a list of material to this group to follow this group policy
      * @return this instance.
      */
-    fun addAll(vararg materials: Material): AbstractMaterialGroup {
+    fun addAll(vararg materials: NamespacedKey): AbstractMaterialGroup {
         for (material in materials) {
             addToPolicy(material)
         }
@@ -60,19 +61,19 @@ abstract class AbstractMaterialGroup(private val name: String) {
     /**
      * Get the group contained material as a set
      */
-    abstract fun getMaterials(): EnumSet<Material>
+    abstract fun getMaterials(): Set<NamespacedKey>
 
     /**
      * Get the group non-inherited material as a set
      */
-    open fun getNonGroupInheritedMaterials(): EnumSet<Material> {
+    open fun getNonGroupInheritedMaterials(): Set<NamespacedKey> {
         return includedMaterial
     }
 
     /**
      * Get the group non-inherited material as a set
      */
-    open fun setNonGroupInheritedMaterials(materials: EnumSet<Material>) {
+    open fun setNonGroupInheritedMaterials(materials: Set<NamespacedKey>) {
         this.includedMaterial.clear()
         this.includedMaterial.addAll(materials)
     }
@@ -102,8 +103,9 @@ abstract class AbstractMaterialGroup(private val name: String) {
         // Test inner material
         val matIterator = includedMaterial.iterator()
         while (matIterator.hasNext()) {
-            val material = matIterator.next()
-            if (material.isAir) continue
+            val key = matIterator.next()
+            val material = MaterialUtil.getMatFromKey(key)
+            if (material == null || material.isAir) continue
             return material
         }
         // Test included group representative material

--- a/src/main/kotlin/xyz/alexcrea/cuanvil/group/EnchantConflictGroup.kt
+++ b/src/main/kotlin/xyz/alexcrea/cuanvil/group/EnchantConflictGroup.kt
@@ -2,6 +2,7 @@ package xyz.alexcrea.cuanvil.group
 
 import io.delilaheve.CustomAnvil
 import org.bukkit.Material
+import org.bukkit.NamespacedKey
 import xyz.alexcrea.cuanvil.enchant.CAEnchantment
 
 class EnchantConflictGroup(
@@ -53,7 +54,7 @@ class EnchantConflictGroup(
         return canBypassByBeforeLevel(enchants) || canBypassByAfterLevel(enchants)
     }
 
-    fun allowed(enchants: Map<CAEnchantment, Int>, mat: Material): Boolean {
+    fun allowed(enchants: Map<CAEnchantment, Int>, mat: NamespacedKey): Boolean {
         if (enchantments.size < minBeforeBlock) {
             CustomAnvil.verboseLog("Conflicting bc of to many enchantments")
             return true

--- a/src/main/kotlin/xyz/alexcrea/cuanvil/group/EnchantConflictManager.kt
+++ b/src/main/kotlin/xyz/alexcrea/cuanvil/group/EnchantConflictManager.kt
@@ -8,6 +8,7 @@ import org.bukkit.inventory.ItemStack
 import xyz.alexcrea.cuanvil.enchant.AdditionalTestEnchantment
 import xyz.alexcrea.cuanvil.enchant.CAEnchantment
 import xyz.alexcrea.cuanvil.enchant.CAEnchantmentRegistry
+import xyz.alexcrea.cuanvil.util.MaterialUtil.customType
 import java.util.*
 import kotlin.collections.set
 
@@ -211,8 +212,8 @@ class EnchantConflictManager {
         item: ItemStack,
         newEnchant: CAEnchantment
     ): ConflictType {
-        val mat = item.type
-        CustomAnvil.verboseLog("Testing conflict for ${newEnchant.key} on ${mat.key}")
+        val type = item.customType
+        CustomAnvil.verboseLog("Testing conflict for ${newEnchant.key} on ${type}")
         val conflictList = newEnchant.conflicts
 
         var result = ConflictType.NO_CONFLICT
@@ -223,7 +224,7 @@ class EnchantConflictManager {
                 continue
             }
 
-            val allowed = conflict.allowed(appliedEnchants, mat)
+            val allowed = conflict.allowed(appliedEnchants, type)
             CustomAnvil.verboseLog("Was against $conflict and conflicting: ${!allowed} ")
             if (!allowed) {
                 if (conflict.getEnchants().size <= 1) {
@@ -239,7 +240,7 @@ class EnchantConflictManager {
         val immutableEnchants = Collections.unmodifiableMap(appliedEnchants)
         for (appliedEnchant in appliedEnchants.keys) {
             if (appliedEnchant is AdditionalTestEnchantment) {
-                val doConflict = appliedEnchant.isEnchantConflict(immutableEnchants, mat)
+                val doConflict = appliedEnchant.isEnchantConflict(immutableEnchants, type)
                 if (doConflict) {
                     CustomAnvil.verboseLog("Big conflict by additional test, stopping")
                     return ConflictType.ENCHANTMENT_CONFLICT
@@ -251,7 +252,7 @@ class EnchantConflictManager {
         if ((result != ConflictType.ITEM_CONFLICT) && (newEnchant is AdditionalTestEnchantment)) {
             val partialItem = createPartialResult(item, immutableEnchants)
 
-            if (newEnchant.isItemConflict(immutableEnchants, mat, partialItem)) {
+            if (newEnchant.isItemConflict(immutableEnchants, type, partialItem)) {
                 return ConflictType.ITEM_CONFLICT
             }
 

--- a/src/main/kotlin/xyz/alexcrea/cuanvil/group/ExcludeGroup.kt
+++ b/src/main/kotlin/xyz/alexcrea/cuanvil/group/ExcludeGroup.kt
@@ -1,11 +1,12 @@
 package xyz.alexcrea.cuanvil.group
 
-import org.bukkit.Material
+import org.bukkit.NamespacedKey
 import java.util.*
 
 class ExcludeGroup(name: String) : AbstractMaterialGroup(name) {
-    override fun createDefaultSet(): EnumSet<Material> {
-        return EnumSet.allOf(Material::class.java)
+
+    override fun createDefaultSet(): MutableSet<NamespacedKey> {
+        return NegativeSet(HashSet())
     }
 
     private var includedGroup: MutableSet<AbstractMaterialGroup> = HashSet()
@@ -20,9 +21,9 @@ class ExcludeGroup(name: String) : AbstractMaterialGroup(name) {
         return false
     }
 
-    override fun addToPolicy(mat: Material): ExcludeGroup {
-        includedMaterial.remove(mat)
-        groupItems.remove(mat)
+    override fun addToPolicy(type: NamespacedKey): ExcludeGroup {
+        includedMaterial.remove(type)
+        groupItems.remove(type)
 
         return this
     }
@@ -60,7 +61,7 @@ class ExcludeGroup(name: String) : AbstractMaterialGroup(name) {
         }
     }
 
-    override fun getMaterials(): EnumSet<Material> {
+    override fun getMaterials(): MutableSet<NamespacedKey> {
         return groupItems
     }
 

--- a/src/main/kotlin/xyz/alexcrea/cuanvil/group/IncludeGroup.kt
+++ b/src/main/kotlin/xyz/alexcrea/cuanvil/group/IncludeGroup.kt
@@ -1,11 +1,12 @@
 package xyz.alexcrea.cuanvil.group
 
 import org.bukkit.Material
+import org.bukkit.NamespacedKey
 import java.util.*
 
 class IncludeGroup(name: String) : AbstractMaterialGroup(name) {
-    override fun createDefaultSet(): EnumSet<Material> {
-        return EnumSet.noneOf(Material::class.java)
+    override fun createDefaultSet(): MutableSet<NamespacedKey> {
+        return HashSet()
     }
 
     private var includedGroup: MutableSet<AbstractMaterialGroup> = HashSet()
@@ -20,9 +21,9 @@ class IncludeGroup(name: String) : AbstractMaterialGroup(name) {
         return false
     }
 
-    override fun addToPolicy(mat: Material): IncludeGroup {
-        includedMaterial.add(mat)
-        groupItems.add(mat)
+    override fun addToPolicy(type: NamespacedKey): IncludeGroup {
+        includedMaterial.add(type)
+        groupItems.add(type)
 
         return this
     }
@@ -47,7 +48,7 @@ class IncludeGroup(name: String) : AbstractMaterialGroup(name) {
         }
     }
 
-    override fun setNonGroupInheritedMaterials(materials: EnumSet<Material>) {
+    override fun setNonGroupInheritedMaterials(materials: Set<NamespacedKey>) {
         super.setNonGroupInheritedMaterials(materials)
 
         updateMaterials()
@@ -66,7 +67,7 @@ class IncludeGroup(name: String) : AbstractMaterialGroup(name) {
         }
     }
 
-    override fun getMaterials(): EnumSet<Material> {
+    override fun getMaterials(): MutableSet<NamespacedKey> {
         return groupItems
     }
 

--- a/src/main/kotlin/xyz/alexcrea/cuanvil/group/ItemGroupManager.kt
+++ b/src/main/kotlin/xyz/alexcrea/cuanvil/group/ItemGroupManager.kt
@@ -91,7 +91,7 @@ class ItemGroupManager {
                 }
                 continue
             }
-            group.addToPolicy(material)
+            group.addToPolicy(material.key)
         }
 
         // Read group to include in this group policy.

--- a/src/main/kotlin/xyz/alexcrea/cuanvil/group/NegativeSet.kt
+++ b/src/main/kotlin/xyz/alexcrea/cuanvil/group/NegativeSet.kt
@@ -1,0 +1,51 @@
+package xyz.alexcrea.cuanvil.group
+
+class NegativeSet<T>(val negate: MutableSet<T>) : MutableSet<T> {
+
+    override fun iterator(): MutableIterator<T> {
+        TODO("Not yet implemented") // can't be implemented I guess
+    }
+
+    override fun add(element: T): Boolean {
+        return negate.remove(element)
+    }
+
+    override fun remove(element: T): Boolean {
+        return negate.add(element)
+    }
+
+    override fun addAll(elements: Collection<T>): Boolean {
+        return negate.removeAll(elements)
+    }
+
+    override fun removeAll(elements: Collection<T>): Boolean {
+        return negate.addAll(elements)
+    }
+
+    override fun retainAll(elements: Collection<T>): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun clear() {
+        TODO("Not yet implemented")
+    }
+
+    override fun isEmpty(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override val size get() = TODO("Not yet implemented")
+
+    override fun contains(element: T): Boolean {
+        return !negate.contains(element)
+    }
+
+    override fun containsAll(elements: Collection<T>): Boolean {
+        for (elm in elements) {
+            if(negate.contains(elm)) return false
+        }
+
+        return true
+    }
+
+}

--- a/src/main/kotlin/xyz/alexcrea/cuanvil/listener/PrepareAnvilListener.kt
+++ b/src/main/kotlin/xyz/alexcrea/cuanvil/listener/PrepareAnvilListener.kt
@@ -93,7 +93,7 @@ class PrepareAnvilListener : Listener {
         if (testCustomRecipe(event, inventory, player, first, second)) return
 
         // Test rename lonely item
-        val isAir = second.isAir()
+        val isAir = second.isAir
         CustomAnvil.verboseLog("checking air in main logic: $isAir")
         if (isAir) {
             doRenaming(event, inventory, player, first)

--- a/src/main/kotlin/xyz/alexcrea/cuanvil/listener/PrepareAnvilListener.kt
+++ b/src/main/kotlin/xyz/alexcrea/cuanvil/listener/PrepareAnvilListener.kt
@@ -24,6 +24,7 @@ import org.bukkit.inventory.meta.ItemMeta
 import xyz.alexcrea.cuanvil.dependency.DependencyManager
 import xyz.alexcrea.cuanvil.enchant.CAEnchantment
 import xyz.alexcrea.cuanvil.util.*
+import xyz.alexcrea.cuanvil.util.MaterialUtil.isAir
 import xyz.alexcrea.cuanvil.util.UnitRepairUtil.getRepair
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -40,10 +41,6 @@ class PrepareAnvilListener : Listener {
         const val ANVIL_OUTPUT_SLOT = 2
 
         var IS_EMPTY_TEST = false
-    }
-
-    private fun ItemStack?.isAir(): Boolean {
-        return this == null || this.type.isAir || this.amount == 0
     }
 
     /**
@@ -121,7 +118,7 @@ class PrepareAnvilListener : Listener {
     }
 
     private fun isImmutable(item: ItemStack?): Boolean {
-        if (item.isAir()) return false
+        if (item.isAir) return false
 
         val meta = item!!.itemMeta
         return meta != null &&
@@ -172,7 +169,7 @@ class PrepareAnvilListener : Listener {
         if (finalResult == null) return false
 
         event.result = finalResult.result
-        if (finalResult.result.isAir()) return false
+        if (finalResult.result.isAir) return false
 
         AnvilXpUtil.setAnvilInvXp(inventory, event.view, player, finalResult.levelCost, true)
         return true
@@ -198,7 +195,7 @@ class PrepareAnvilListener : Listener {
         if (finalResult == null) return
 
         event.result = finalResult.result
-        if (finalResult.result.isAir()) return
+        if (finalResult.result.isAir) return
 
         AnvilXpUtil.setAnvilInvXp(inventory, event.view, player, finalResult.levelCost)
     }
@@ -286,7 +283,7 @@ class PrepareAnvilListener : Listener {
         if (finalResult == null) return
 
         event.result = finalResult.result
-        if (finalResult.result.isAir()) return
+        if (finalResult.result.isAir) return
 
         AnvilXpUtil.setAnvilInvXp(inventory, event.view, player, finalResult.levelCost)
     }
@@ -331,7 +328,7 @@ class PrepareAnvilListener : Listener {
         if (finalResult == null) return false
 
         event.result = finalResult.result
-        if (finalResult.result.isAir()) return false
+        if (finalResult.result.isAir) return false
 
         AnvilXpUtil.setAnvilInvXp(inventory, event.view, player, finalResult.levelCost)
         return true
@@ -351,7 +348,7 @@ class PrepareAnvilListener : Listener {
             result = AnvilLoreEditUtil.tryLoreEditByPaper(player, first, second, xpCost)
         }
 
-        if (result.isAir() || first == result) {
+        if (result.isAir || first == result) {
             CustomAnvil.log("lore edit, But input is same as output")
             event.result = null
             return false

--- a/src/main/kotlin/xyz/alexcrea/cuanvil/recipe/AnvilCustomRecipe.kt
+++ b/src/main/kotlin/xyz/alexcrea/cuanvil/recipe/AnvilCustomRecipe.kt
@@ -7,6 +7,7 @@ import xyz.alexcrea.cuanvil.config.ConfigHolder
 import xyz.alexcrea.cuanvil.gui.util.GuiSharedConstant
 import xyz.alexcrea.cuanvil.util.AnvilUseType
 import xyz.alexcrea.cuanvil.util.AnvilXpUtil
+import xyz.alexcrea.cuanvil.util.MaterialUtil.isAir
 
 class AnvilCustomRecipe(
     val name: String,
@@ -80,11 +81,7 @@ class AnvilCustomRecipe(
     }
 
     fun validate(): Boolean {
-        return (leftItem != null) && !(leftItem!!.type.isAir) && (leftItem!!.amount > 0) &&
-                //(rightItem != null) && !(rightItem!!.type.isAir) && (rightItem!!.amount > 0) &&
-                ((rightItem == null) || (!(rightItem!!.type.isAir) && (rightItem!!.amount > 0))) &&
-                (resultItem != null) && !(resultItem!!.type.isAir) && (resultItem!!.amount > 0)
-
+        return !leftItem.isAir && !rightItem.isAir && !resultItem.isAir
     }
 
     fun saveToFile(writeFile: Boolean, doBackup: Boolean) {

--- a/src/main/kotlin/xyz/alexcrea/cuanvil/recipe/AnvilCustomRecipe.kt
+++ b/src/main/kotlin/xyz/alexcrea/cuanvil/recipe/AnvilCustomRecipe.kt
@@ -81,7 +81,9 @@ class AnvilCustomRecipe(
     }
 
     fun validate(): Boolean {
-        return !leftItem.isAir && !rightItem.isAir && !resultItem.isAir
+        return !leftItem.isAir &&
+                (rightItem == null || !resultItem.isAir) &&
+                !resultItem.isAir
     }
 
     fun saveToFile(writeFile: Boolean, doBackup: Boolean) {
@@ -159,7 +161,7 @@ class AnvilCustomRecipe(
         CustomAnvil.verboseLog("Testing $name $leftItem")
         // We assume this function can be call only if leftItem != null
 
-        // Test is valid
+        // Test if valid
         if (!validate()) return false
 
         val leftSimilar = leftItem!!.isSimilar(item1)

--- a/src/main/kotlin/xyz/alexcrea/cuanvil/util/MaterialUtil.kt
+++ b/src/main/kotlin/xyz/alexcrea/cuanvil/util/MaterialUtil.kt
@@ -1,0 +1,61 @@
+package xyz.alexcrea.cuanvil.util
+
+import org.bukkit.Bukkit
+import org.bukkit.Material
+import org.bukkit.NamespacedKey
+import org.bukkit.inventory.ItemStack
+import xyz.alexcrea.cuanvil.dependency.plugins.EcoItemDependencyUtil
+
+object MaterialUtil {
+
+    val ItemStack?.isAir: Boolean
+        get() {
+            return this == null || this.type.isAir || this.amount == 0
+        }
+
+    val NamespacedKey?.isAir: Boolean
+        get() {
+            return Material.AIR.key == this
+        }
+
+    private val HasEcoItem = Bukkit.getPluginManager().isPluginEnabled("EcoItems")
+
+    val ItemStack.customType: NamespacedKey
+        get() {
+            if(HasEcoItem) {
+                val result = EcoItemDependencyUtil.ecoItemNamespace(this)
+                if(result != null) return result
+            }
+
+            return this.type.key
+        }
+
+    private fun bukkitMaterialFromKey(key: NamespacedKey): Material? {
+        //TODO on paper only transition Registry.MATERIAL.get(key)
+        return Material.matchMaterial(key.toString())
+    }
+
+    fun getMatFromKey(key: NamespacedKey): Material? {
+        if(HasEcoItem) {
+            val result = EcoItemDependencyUtil.ecoItemMaterialFromKey(key)
+            if(result != null) return result
+        }
+
+        return bukkitMaterialFromKey(key)
+    }
+
+    fun itemFromKey(key: NamespacedKey): ItemStack {
+        if(HasEcoItem) {
+            val result = EcoItemDependencyUtil.newEcoItemstack(key)
+            if(result != null) return result
+        }
+
+        return ItemStack(bukkitMaterialFromKey(key)!!)
+    }
+
+    fun materialExist(key: NamespacedKey): Boolean {
+        return getMatFromKey(key) != null
+    }
+
+
+}

--- a/src/main/kotlin/xyz/alexcrea/cuanvil/util/UnitRepairUtil.kt
+++ b/src/main/kotlin/xyz/alexcrea/cuanvil/util/UnitRepairUtil.kt
@@ -3,6 +3,7 @@ package xyz.alexcrea.cuanvil.util
 import org.bukkit.configuration.ConfigurationSection
 import org.bukkit.inventory.ItemStack
 import xyz.alexcrea.cuanvil.config.ConfigHolder
+import xyz.alexcrea.cuanvil.util.MaterialUtil.customType
 
 object UnitRepairUtil {
 
@@ -22,7 +23,7 @@ object UnitRepairUtil {
         if (other == null) return null
         val config = ConfigHolder.UNIT_REPAIR_HOLDER.config
         // Get configuration section if exist
-        val otherName = other.type.name.lowercase()
+        val otherName = other.customType.key.lowercase()
         var section = config.getConfigurationSection(otherName)
         if (section == null) {
             section = config.getConfigurationSection(otherName.uppercase())
@@ -44,7 +45,7 @@ object UnitRepairUtil {
      * If value is set to less than or equal to 0 then it will be set to default
      */
     private fun getRepairAmount(item: ItemStack, section: ConfigurationSection, default: Double): Double? {
-        val itemName = item.type.name.lowercase()
+        val itemName = item.customType.key.lowercase()
         val repairValue = if (section.isDouble(itemName)) {
             section.getDouble(itemName)
         } else if (section.isDouble(itemName.uppercase())) {

--- a/src/test/java/xyz/alexcrea/cuanvil/api/MaterialGroupApiTests.java
+++ b/src/test/java/xyz/alexcrea/cuanvil/api/MaterialGroupApiTests.java
@@ -15,7 +15,7 @@ public class MaterialGroupApiTests extends ConfigResetCustomAnvilTest {
     void groupAddAndRemove() {
         String groupName = "group";
         IncludeGroup group = new IncludeGroup(groupName);
-        group.addToPolicy(Material.DIAMOND_PICKAXE); // We do not want it to be empty
+        group.addToPolicy(Material.DIAMOND_PICKAXE.getKey()); // We do not want it to be empty
 
         // Group not being set should not exist
         assertFalse(doGroupExist(groupName));
@@ -48,7 +48,7 @@ public class MaterialGroupApiTests extends ConfigResetCustomAnvilTest {
     void writeGroup_Reload() {
         String groupName = "group";
         IncludeGroup group = new IncludeGroup(groupName);
-        group.addToPolicy(Material.DIAMOND_PICKAXE); // We do not want it to be empty
+        group.addToPolicy(Material.DIAMOND_PICKAXE.getKey()); // We do not want it to be empty
 
         // Group not being set should not exist
         assertFalse(doGroupExist(groupName));


### PR DESCRIPTION
Use material key instead of material enum

This is made with the goal of making eco item work as independant item.
so item type key now depend on eco item's id 