### PR TITLE
Refactor GitHub Workflow to avoid issues in Changelog

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,6 +25,10 @@ jobs:
     permissions:
       contents: write
 
+    env:
+      MODRINTH_VERSIONS: '["1.18.x", "1.19.x", "1.20.x", "1.21.x"]'
+      MODRINTH_PLATFORMS: '["spigot", "paper", "purpur", "folia"]'
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDKs
@@ -65,19 +69,6 @@ jobs:
       - name: Get small commit hash
         if: ${{ github.event_name != 'release' && success() }}
         run: echo "SMALL_COMMIT_HASH=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
-
-      - name: Prepare release env variable
-        if: ${{ github.event_name == 'release' && success() }}
-        run: |
-          echo "RELEASE_CHANGELOG<<EOF" >> $GITHUB_ENV
-          echo "${{ github.event.release.body || '' }}" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-          echo "IS_GITHUB_PRERELEASE=${{ github.event.release.prerelease }}" >> $GITHUB_ENV
-
-      - name: Prepare publish env variable
-        run: |
-          echo MODRINTH_VERSIONS='["1.18.x", "1.19.x", "1.20.x", "1.21.x"]' >> $GITHUB_ENV
-          echo MODRINTH_PLATFORMS='["spigot", "paper", "purpur", "folia"]' >> $GITHUB_ENV
 
       - name: Build with Gradle Wrapper
         run: ./gradlew build --parallel --stacktrace
@@ -128,6 +119,7 @@ jobs:
         if: ${{ (github.event_name != 'release' || github.event_name != 'push') && github.repository_owner == 'alexcrea' && success() }}
         env:
           HANGAR_API_TOKEN: ${{ secrets.HANGAR_API_TOKEN }}
+          RELEASE_CHANGELOG: ${{ github.event.release.body }}
         run: ./gradlew publishAllPublicationsToHangar --stacktrace
 
       - name: Modrinth publish alpha
@@ -156,7 +148,7 @@ jobs:
           game-versions: ${{ env.MODRINTH_VERSIONS }}
           channel: ${{ github.event.release.prerelease == false && 'release' || 'beta' }}
           files: build/libs/${{ env.ONLINE_JAR_NAME }}
-          changelog: ${{ env.RELEASE_CHANGELOG }}
+          changelog: ${{ github.event.release.body }}
 
       - name: Send release note to discord
         if: ${{ github.event_name == 'release' && github.repository_owner == 'alexcrea' && success() }}
@@ -168,4 +160,4 @@ jobs:
             # New ${{ github.event.release.prerelease && 'beta' || '' }} version of custom anvil ! <:CustomAnvil:1262550667986342001>([Modrinth](https://modrinth.com/plugin/customanvil), [Hangar](https://hangar.papermc.io/alexcrea/CustomAnvil) and [GitHub](${{ github.event.release.html_url }}) links)
             -# note: automated release. spigot is not uploaded yet.
 
-            ${{ env.RELEASE_CHANGELOG }}
+            ${{ github.event.release.body }}


### PR DESCRIPTION
Hi!

This PR should make quotes and other special characters usable inside the release notes.
I tested it locally using `act` with a mock event and my own discord webhook, the post inside discord looks identical, and it works with quotes too.

That was just a mock event though, actual github events might behave differently.